### PR TITLE
handle enums when key passed instead of value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # metadata-schemas
+
+[![PyPI version](https://badge.fury.io/py/metadataschemas.svg)](https://badge.fury.io/py/metadataschemas)
+
 This repository contains both the definitions of Metadata Schemas and a python library for creating schema objects with pydantic and Excel.
 
 ## Defining Metadata Schemas

--- a/pydantic_schemas/document_schema.py
+++ b/pydantic_schemas/document_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -256,7 +256,7 @@ class Discipline(SchemaBaseModel):
     uri: Optional[str] = Field(None, description="Website link", title="URI")
 
 
-class Type(Enum):
+class Type(EnumWithValueOrKey):
     isPartOf = "isPartOf"
     hasPart = "hasPart"
     isVersionOf = "isVersionOf"
@@ -595,10 +595,8 @@ class ScriptSchemaDraft(SchemaBaseModel):
     """
     Schema for Document data type
     """
-
     _metadata_type__:str = PrivateAttr("document")
     _metadata_type_version__:str = PrivateAttr("0.1.0") 
-
 
     idno: Optional[str] = Field(
         None, description="Project unique identifier", title="Project unique identifier"

--- a/pydantic_schemas/generators/generate_pydantic_schemas.py
+++ b/pydantic_schemas/generators/generate_pydantic_schemas.py
@@ -74,5 +74,15 @@ for section, details in data.items():
         updated_content,
     )
 
+    # replace from enum import Enum with rom .utils.enum_with_value_or_key import EnumWithValueOrKey
+    updated_content = re.sub(
+        r"from enum import Enum",
+        "from .utils.enum_with_value_or_key import EnumWithValueOrKey",
+        updated_content,
+    )
+
+    # replace (Enum) with (EnumWithValueOrKey)
+    updated_content = re.sub(r"\(Enum\)", "(EnumWithValueOrKey)", updated_content)
+
     with open(output_path, "w") as file:
         file.write(updated_content)

--- a/pydantic_schemas/geospatial_schema.py
+++ b/pydantic_schemas/geospatial_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, RootModel, confloat, PrivateAttr
@@ -226,12 +226,12 @@ class Geohash(SchemaBaseModel):
     note: Optional[str] = Field(None, title="Note")
 
 
-class Ring(Enum):
+class Ring(EnumWithValueOrKey):
     exterior = "exterior"
     interior = "interior"
 
 
-class Type(Enum):
+class Type(EnumWithValueOrKey):
     Point = "Point"
     LineString = "LineString"
     Polygon = "Polygon"

--- a/pydantic_schemas/image_schema.py
+++ b/pydantic_schemas/image_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, confloat, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import AnyUrl, AwareDatetime, ConfigDict, Field, confloat, Private
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite document if already exists?
     """
@@ -100,7 +100,7 @@ class SubjectCodesLabelledItem(SchemaBaseModel):
     )
 
 
-class Delimitertype(Enum):
+class Delimitertype(EnumWithValueOrKey):
     spatial = "spatial"
     temporal = "temporal"
 
@@ -581,7 +581,7 @@ class Rating(SchemaBaseModel):
     )
 
 
-class MeasureType(Enum):
+class MeasureType(EnumWithValueOrKey):
     """
     How the measures of the rectangle are expressed
     """
@@ -670,7 +670,7 @@ class TemporalCoverage(SchemaBaseModel):
     )
 
 
-class TimeFormat(Enum):
+class TimeFormat(EnumWithValueOrKey):
     """
     Identifier of the time format. For time code formats following SMPTE specifications.
     """
@@ -755,7 +755,7 @@ class Language(SchemaBaseModel):
     code: Optional[str] = Field(None, title="Code")
 
 
-class Type(Enum):
+class Type(EnumWithValueOrKey):
     isPartOf = "isPartOf"
     hasPart = "hasPart"
     isVersionOf = "isVersionOf"

--- a/pydantic_schemas/indicator_schema.py
+++ b/pydantic_schemas/indicator_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -604,7 +604,7 @@ class SeriesDescription(SchemaBaseModel):
     )
 
 
-class DataType(Enum):
+class DataType(EnumWithValueOrKey):
     string = "string"
     integer = "integer"
     float = "float"
@@ -612,7 +612,7 @@ class DataType(Enum):
     boolean = "boolean"
 
 
-class ColumnType(Enum):
+class ColumnType(EnumWithValueOrKey):
     dimension = "dimension"
     time_period = "time_period"
     measure = "measure"
@@ -624,7 +624,7 @@ class ColumnType(Enum):
     observation_value = "observation_value"
 
 
-class TimePeriodFormat(Enum):
+class TimePeriodFormat(EnumWithValueOrKey):
     YYYY = "YYYY"
     YYYY_MM = "YYYY-MM"
     YYYY_MM_DD = "YYYY-MM-DD"
@@ -655,7 +655,7 @@ class DataStructureItem(SchemaBaseModel):
     )
 
 
-class Operator(Enum):
+class Operator(EnumWithValueOrKey):
     field_ = "="
     field__ = "!="
     field__1 = "<"
@@ -684,7 +684,7 @@ class Tag(SchemaBaseModel):
     tag_group: Optional[str] = Field(None, title="Tag group")
 
 
-class NameType(Enum):
+class NameType(EnumWithValueOrKey):
     Personal = "Personal"
     Organizational = "Organizational"
 
@@ -696,7 +696,7 @@ class Creator(SchemaBaseModel):
     familyName: Optional[str] = Field(None, title="Family name")
 
 
-class TitleType(Enum):
+class TitleType(EnumWithValueOrKey):
     AlternativeTitle = "AlternativeTitle"
     Subtitle = "Subtitle"
     TranslatedTitle = "TranslatedTitle"
@@ -709,7 +709,7 @@ class Title(SchemaBaseModel):
     lang: Optional[str] = Field(None, title="Language")
 
 
-class ResourceTypeGeneral(Enum):
+class ResourceTypeGeneral(EnumWithValueOrKey):
     Audiovisual = "Audiovisual"
     Collection = "Collection"
     DataPaper = "DataPaper"

--- a/pydantic_schemas/indicators_db_schema.py
+++ b/pydantic_schemas/indicators_db_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import ConfigDict, Field, PrivateAttr
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite database if already exists?
     """

--- a/pydantic_schemas/microdata_schema.py
+++ b/pydantic_schemas/microdata_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import ConfigDict, Field, constr, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import ConfigDict, Field, constr, PrivateAttr
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class AccessPolicy(Enum):
+class AccessPolicy(EnumWithValueOrKey):
     """
     Data access policy for attached microdata resources
     """
@@ -24,7 +24,7 @@ class AccessPolicy(Enum):
     data_na = "data_na"
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite survey if already exists?
     """
@@ -56,7 +56,7 @@ class DatafileSchema(SchemaBaseModel):
     notes: Optional[str] = Field(None, title="File notes")
 
 
-class VarIntrvl(Enum):
+class VarIntrvl(EnumWithValueOrKey):
     """
     indicates the interval type; options are discrete or continuous.
     """
@@ -201,7 +201,7 @@ class VariableSchema(SchemaBaseModel):
     var_notes: Optional[str] = Field(None, title="Variable notes")
 
 
-class GroupType(Enum):
+class GroupType(EnumWithValueOrKey):
     subject = "subject"
     section = "section"
     multiResp = "multiResp"

--- a/pydantic_schemas/script_schema.py
+++ b/pydantic_schemas/script_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import ConfigDict, Field, PrivateAttr
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite document if already exists?
     """

--- a/pydantic_schemas/table_schema.py
+++ b/pydantic_schemas/table_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, RootModel, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import ConfigDict, Field, RootModel, PrivateAttr
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite document if already exists?
     """
@@ -309,7 +309,7 @@ class Note(SchemaBaseModel):
     note: Optional[str] = Field(None, title="Note")
 
 
-class Type(Enum):
+class Type(EnumWithValueOrKey):
     isPartOf = "isPartOf"
     hasPart = "hasPart"
     isVersionOf = "isVersionOf"

--- a/pydantic_schemas/tests/test_enums.py
+++ b/pydantic_schemas/tests/test_enums.py
@@ -1,0 +1,152 @@
+from typing import List, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from ..utils.enum_with_value_or_key import EnumWithValueOrKey
+
+
+def test_enum_with_value_or_key():
+    class IndicatorType(EnumWithValueOrKey):
+        Concept = "concept"
+        Disaggregation = "disaggregation"
+        Derivation = "derivation"
+
+    # This will work
+    assert IndicatorType("concept") == IndicatorType.Concept
+    assert IndicatorType("Concept") == IndicatorType.Concept
+
+    # This will raise a ValidationError
+    with pytest.raises(ValueError):
+        IndicatorType("Invalid")
+
+
+def test_pydantic_with_enum():
+    class IndicatorType(EnumWithValueOrKey):
+        Concept = "concept"
+        Disaggregation = "disaggregation"
+        Derivation = "derivation"
+
+    class Indicator(BaseModel):
+        type: IndicatorType
+
+    indicator = Indicator(type="concept")
+    assert indicator.type == IndicatorType.Concept
+
+    indicator = Indicator(type="Concept")
+    assert indicator.type == IndicatorType.Concept
+
+    with pytest.raises(ValueError):
+        Indicator(type="Invalid")
+
+    # now with optional type
+    class Indicator(BaseModel):
+        type: Optional[IndicatorType] = None
+
+    indicator = Indicator(type="concept")
+    assert indicator.type == IndicatorType.Concept
+
+    indicator = Indicator(type="Concept")
+    assert indicator.type == IndicatorType.Concept
+
+    with pytest.raises(ValueError):
+        Indicator(type="Invalid")
+
+    Indicator.model_validate({"type": "concept"})
+    Indicator.model_validate({"type": "Concept"})
+
+    # now with a list of types
+    class Indicator(BaseModel):
+        types: List[IndicatorType]
+
+    indicator = Indicator(types=["concept", "disaggregation"])
+    assert indicator.types == [IndicatorType.Concept, IndicatorType.Disaggregation]
+
+    indicator = Indicator(types=["Concept", "Disaggregation"])
+    assert indicator.types == [IndicatorType.Concept, IndicatorType.Disaggregation]
+
+    with pytest.raises(ValueError):
+        Indicator(types=["Invalid"])
+
+    with pytest.raises(ValueError):
+        Indicator(types=["Concept", "Invalid"])
+
+    Indicator.model_validate({"types": ["concept", "Disaggregation"]})
+
+    # now with optional list of types
+    class Indicator(BaseModel):
+        types: Optional[List[IndicatorType]] = None
+
+    indicator = Indicator()
+    assert indicator.types is None
+
+    indicator = Indicator(types=[])
+    assert indicator.types == []
+
+    indicator = Indicator(types=["concept", "disaggregation"])
+    assert indicator.types == [IndicatorType.Concept, IndicatorType.Disaggregation]
+
+    indicator = Indicator(types=["Concept", "Disaggregation"])
+    assert indicator.types == [IndicatorType.Concept, IndicatorType.Disaggregation]
+
+    with pytest.raises(ValueError):
+        Indicator(types=["Invalid"])
+
+    Indicator.model_validate({"types": ["concept", "Disaggregation"]})
+
+    # now where the enum is a subfield
+    class Indicator(BaseModel):
+        type: IndicatorType
+
+    class Parent(BaseModel):
+        indicator: Indicator
+
+    parent = Parent(indicator={"type": "concept"})
+    assert parent.indicator.type == IndicatorType.Concept
+
+    parent = Parent(indicator={"type": "Concept"})
+    assert parent.indicator.type == IndicatorType.Concept
+
+    with pytest.raises(ValueError):
+        Parent(indicator={"type": "Invalid"})
+
+    Parent.model_validate({"indicator": {"type": "concept"}})
+
+
+def test_mixed_types():
+    class IndicatorType(EnumWithValueOrKey):
+        One = 1
+        Two = 2
+
+    IndicatorType(1)
+    IndicatorType(2)
+
+    IndicatorType("One")
+    IndicatorType("Two")
+
+    with pytest.raises(ValueError):
+        IndicatorType(3)
+
+    with pytest.raises(ValueError):
+        IndicatorType("Three")
+
+    class Indicator(BaseModel):
+        type: IndicatorType
+
+    indicator = Indicator(type=1)
+    assert indicator.type == IndicatorType.One
+
+    indicator = Indicator(type=2)
+    assert indicator.type == IndicatorType.Two
+
+    indicator = Indicator(type="One")
+    assert indicator.type == IndicatorType.One
+
+    indicator = Indicator(type="Two")
+    assert indicator.type == IndicatorType.Two
+
+    with pytest.raises(ValueError):
+        Indicator(type=3)
+
+    with pytest.raises(ValueError):
+        Indicator(type="Three")

--- a/pydantic_schemas/utils/enum_with_value_or_key.py
+++ b/pydantic_schemas/utils/enum_with_value_or_key.py
@@ -1,0 +1,46 @@
+from enum import Enum
+
+
+class EnumWithValueOrKey(Enum):
+    """A custom Enum that allows input values to be either the key or the value.
+
+    Users of the Metadata Editor tend to put either the key or the value of an Enum.
+
+    For example I was seeing errors like:
+
+    series_description.related_indicators.1.type
+      Input should be 'concept', 'disaggregation' or 'derivation' [type=enum, input_value='Derivation', input_type=str]
+        For further information visit https://errors.pydantic.dev/2.10/v/enum/
+
+    This custom Enum class allows the input to be either the key or the value of the Enum.
+
+    Example:
+    ```python
+    class IndicatorType(EnumWithValueOrKey):
+        Concept = "concept"
+        Disaggregation = "disaggregation"
+        Derivation = "derivation"
+
+    # Example usage:
+
+    # This will work
+    IndicatorType("concept")  # gives IndicatorType.Concept
+    IndicatorType("Concept")  # gives IndicatorType.Concept
+
+    # This will raise a ValidationError
+    IndicatorType("Invalid")
+    ```
+    """
+
+    @classmethod
+    def _missing_(cls, value):
+        """Handle both keys (names) and values for Enum."""
+        # Check if the value is a valid key (name)
+        if isinstance(value, str):
+            # Try to map the string value to the Enum's key
+            for item in cls:
+                if item.name == value or item.value == value:  # case-insensitive check
+                    return item
+            raise ValueError(f"{value} is not a valid {cls.__name__}")  # Raise if input is neither key nor value
+        # proceed as usual
+        return super()._missing_(value)

--- a/pydantic_schemas/video_schema.py
+++ b/pydantic_schemas/video_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from .utils.enum_with_value_or_key import EnumWithValueOrKey
 from typing import Any, Dict, List, Optional
 
 from pydantic import ConfigDict, Field, PrivateAttr
@@ -11,7 +11,7 @@ from pydantic import ConfigDict, Field, PrivateAttr
 from .utils.schema_base_model import SchemaBaseModel
 
 
-class Overwrite(Enum):
+class Overwrite(EnumWithValueOrKey):
     """
     Overwrite document if already exists?
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadataschemas"
-version = "0.1.1"
+version = "0.1.2"
 description = "A library of metadata schemas for documents, geospatial, image, indicator (timeseries), microdata (ddi), script, table and video data"
 authors = ["Mehmood Asghar <masghar@worldbank.org>", "Gordon Blackadder <gblackadder@worldbank.org>"]
 readme = "README.md"
@@ -10,6 +10,10 @@ packages = [
     { include = "metadata_manager.py", from = "pydantic_schemas", to = "metadataschemas"},
     { include = "utils", from = "pydantic_schemas", to = "metadataschemas"},
 ]
+
+[project.urls]
+repository = "https://github.com/worldbank/metadata-schemas"
+homepage = "https://github.com/worldbank/metadata-schemas"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
For pyMetadataEditor, the enums in templates can be ignored. But we don't have that option here since the enums are in the base types. So instead, make the enum robust to receiving the key as well as the value at instantiation.

For example I was seeing errors like:

series_description.related_indicators.1.type

  Input should be 'concept', 'disaggregation' or 'derivation' [type=enum, input_value='Derivation', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/enum/
I have written a custom Enum class that allows the input to be either the key or the value of the Enum.

Example:

    class IndicatorType(EnumWithValueOrKey):
        Concept = "concept"
        Disaggregation = "disaggregation"
        Derivation = "derivation"
        
    # Example usage:
    # This will work
    IndicatorType("concept")  # gives IndicatorType.Concept
    IndicatorType("Concept")  # gives IndicatorType.Concept
    
    # This will raise a ValidationError
    IndicatorType("Invalid")