### PR TITLE
Allow saving to excel for entities without parent schemas like admin metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadataschemas"
-version = "0.1.2"
+version = "0.1.3"
 description = "A library of metadata schemas for documents, geospatial, image, indicator (timeseries), microdata (ddi), script, table and video data"
 authors = ["Mehmood Asghar <masghar@worldbank.org>", "Gordon Blackadder <gblackadder@worldbank.org>"]
 readme = "README.md"


### PR DESCRIPTION
Previously we forced every metadata object written to excel to map back to a schema defined in this library. But now, if a metadata object is not defined, we simply fall back onto writing on a single page